### PR TITLE
fix: Fix architecture for Windows ARM64 in GetCommandTests

### DIFF
--- a/Devantler.KubectlCLI.Tests/KubectlTests/GetCommandTests.cs
+++ b/Devantler.KubectlCLI.Tests/KubectlTests/GetCommandTests.cs
@@ -16,7 +16,7 @@ public class GetCommandTests
   [InlineData(PlatformID.Unix, Architecture.X64, "linux-x64", "kubectl-linux-x64")]
   [InlineData(PlatformID.Unix, Architecture.Arm64, "linux-arm64", "kubectl-linux-arm64")]
   [InlineData(PlatformID.Win32NT, Architecture.X64, "win-x64", "kubectl-win-x64.exe")]
-  [InlineData(PlatformID.Win32NT, Architecture.X64, "win-arm64", "kubectl-win-arm64.exe")]
+  [InlineData(PlatformID.Win32NT, Architecture.Arm64, "win-arm64", "kubectl-win-arm64.exe")]
   public void GetCommand_ShouldReturnOSXx64Binary(PlatformID platformID, Architecture architecture, string runtimeIdentifier, string expectedBinary)
   {
     // Act

--- a/Devantler.KubectlCLI/Kubectl.cs
+++ b/Devantler.KubectlCLI/Kubectl.cs
@@ -26,7 +26,7 @@ public static class Kubectl
       (PlatformID.Unix, Architecture.X64, "linux-x64") => "kubectl-linux-x64",
       (PlatformID.Unix, Architecture.Arm64, "linux-arm64") => "kubectl-linux-arm64",
       (PlatformID.Win32NT, Architecture.X64, "win-x64") => "kubectl-win-x64.exe",
-      (PlatformID.Win32NT, Architecture.X64, "win-arm64") => "kubectl-win-arm64.exe",
+      (PlatformID.Win32NT, Architecture.Arm64, "win-arm64") => "kubectl-win-arm64.exe",
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);


### PR DESCRIPTION
Correct the architecture designation for Windows ARM64 in the GetCommandTests to ensure accurate test results.