### PR TITLE
fix: Improve binary path handling and set execute permissions for non-Windows platforms

### DIFF
--- a/Devantler.KubectlCLI/Kubectl.cs
+++ b/Devantler.KubectlCLI/Kubectl.cs
@@ -30,9 +30,15 @@ public static class Kubectl
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);
-    return !File.Exists(binaryPath) ?
-      throw new FileNotFoundException($"{binaryPath} not found.") :
-      Cli.Wrap(binaryPath);
+    if (!File.Exists(binaryPath))
+    {
+      throw new FileNotFoundException($"{binaryPath} not found.");
+    }
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      File.SetUnixFileMode(binaryPath, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+    }
+    return Cli.Wrap(binaryPath);
   }
 
   /// <summary>


### PR DESCRIPTION
Enhance the handling of binary paths by ensuring execute permissions are set for non-Windows platforms. This change also improves error handling for missing binaries.